### PR TITLE
feat: MSSQL document loader and saver

### DIFF
--- a/src/langchain_google_cloud_sql_mssql/__init__.py
+++ b/src/langchain_google_cloud_sql_mssql/__init__.py
@@ -16,6 +16,14 @@ from langchain_google_cloud_sql_mssql.mssql_chat_message_history import (
     MSSQLChatMessageHistory,
 )
 from langchain_google_cloud_sql_mssql.mssql_engine import MSSQLEngine
-from langchain_google_cloud_sql_mssql.mssql_loader import MSSQLLoader
+from langchain_google_cloud_sql_mssql.mssql_loader import (
+    MSSQLDocumentSaver,
+    MSSQLLoader,
+)
 
-__all__ = ["MSSQLChatMessageHistory", "MSSQLEngine", "MSSQLLoader"]
+__all__ = [
+    "MSSQLChatMessageHistory",
+    "MSSQLEngine",
+    "MSSQLLoader",
+    "MSSQLDocumentSaver",
+]

--- a/src/langchain_google_cloud_sql_mssql/mssql_engine.py
+++ b/src/langchain_google_cloud_sql_mssql/mssql_engine.py
@@ -15,14 +15,10 @@
 # TODO: Remove below import when minimum supported Python version is 3.10
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import List, Optional
 
 import sqlalchemy
 from google.cloud.sql.connector import Connector
-
-if TYPE_CHECKING:
-    import google.auth.credentials
-    import pytds
 
 
 class MSSQLEngine:

--- a/src/langchain_google_cloud_sql_mssql/mssql_engine.py
+++ b/src/langchain_google_cloud_sql_mssql/mssql_engine.py
@@ -148,3 +148,55 @@ class MSSQLEngine:
         with self.engine.connect() as conn:
             conn.execute(sqlalchemy.text(create_table_query))
             conn.commit()
+
+    def init_document_table(
+        self,
+        table_name: str,
+        metadata_columns: List[sqlalchemy.Column] = [],
+        store_metadata: bool = True,
+    ) -> None:
+        """
+        Create a table for saving of langchain documents.
+
+        Args:
+            table_name (str): The MySQL database table name.
+            metadata_columns (List[sqlalchemy.Column]): A list of SQLAlchemy Columns
+                to create for custom metadata. Optional.
+            store_metadata (bool): Whether to store extra metadata in a metadata column
+                if not described in 'metadata' field list (Default: True).
+        """
+        columns = [
+            sqlalchemy.Column(
+                "page_content",
+                sqlalchemy.UnicodeText,
+                primary_key=False,
+                nullable=False,
+            )
+        ]
+        columns += metadata_columns
+        if store_metadata:
+            columns.append(
+                sqlalchemy.Column(
+                    "langchain_metadata",
+                    sqlalchemy.JSON,
+                    primary_key=False,
+                    nullable=True,
+                )
+            )
+        sqlalchemy.Table(table_name, sqlalchemy.MetaData(), *columns).create(
+            self.engine
+        )
+
+    def _load_document_table(self, table_name: str) -> sqlalchemy.Table:
+        """
+        Load table schema from existing table in MySQL database.
+
+        Args:
+            table_name (str): The MySQL database table name.
+
+        Returns:
+            (sqlalchemy.Table): The loaded table.
+        """
+        metadata = sqlalchemy.MetaData()
+        sqlalchemy.MetaData.reflect(metadata, bind=self.engine, only=[table_name])
+        return metadata.tables[table_name]

--- a/src/langchain_google_cloud_sql_mssql/mssql_engine.py
+++ b/src/langchain_google_cloud_sql_mssql/mssql_engine.py
@@ -159,7 +159,7 @@ class MSSQLEngine:
         Create a table for saving of langchain documents.
 
         Args:
-            table_name (str): The MySQL database table name.
+            table_name (str): The MSSQL database table name.
             metadata_columns (List[sqlalchemy.Column]): A list of SQLAlchemy Columns
                 to create for custom metadata. Optional.
             store_metadata (bool): Whether to store extra metadata in a metadata column
@@ -189,10 +189,10 @@ class MSSQLEngine:
 
     def _load_document_table(self, table_name: str) -> sqlalchemy.Table:
         """
-        Load table schema from existing table in MySQL database.
+        Load table schema from existing table in MSSQL database.
 
         Args:
-            table_name (str): The MySQL database table name.
+            table_name (str): The MSSQL database table name.
 
         Returns:
             (sqlalchemy.Table): The loaded table.

--- a/src/langchain_google_cloud_sql_mssql/mssql_engine.py
+++ b/src/langchain_google_cloud_sql_mssql/mssql_engine.py
@@ -15,10 +15,14 @@
 # TODO: Remove below import when minimum supported Python version is 3.10
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 import sqlalchemy
 from google.cloud.sql.connector import Connector
+
+if TYPE_CHECKING:
+    import google.auth.credentials
+    import pytds
 
 
 class MSSQLEngine:

--- a/src/langchain_google_cloud_sql_mssql/mssql_loader.py
+++ b/src/langchain_google_cloud_sql_mssql/mssql_loader.py
@@ -180,9 +180,8 @@ class MSSQLDocumentSaver:
         with self.engine.connect() as conn:
             for doc in docs:
                 row = _parse_row_from_doc(self._table.columns.keys(), doc)
-                for k, v in row.items():
-                    if type(v) == dict:
-                        row[k] = json.dumps(v)
+                if DEFAULT_METADATA_COL in row:
+                    row[DEFAULT_METADATA_COL] = json.dumps(row[DEFAULT_METADATA_COL])
                 conn.execute(sqlalchemy.insert(self._table).values(row))
             conn.commit()
 
@@ -197,9 +196,8 @@ class MSSQLDocumentSaver:
         with self.engine.connect() as conn:
             for doc in docs:
                 row = _parse_row_from_doc(self._table.columns.keys(), doc)
-                for k, v in row.items():
-                    if type(v) == dict:
-                        row[k] = json.dumps(v)
+                if DEFAULT_METADATA_COL in row:
+                    row[DEFAULT_METADATA_COL] = json.dumps(row[DEFAULT_METADATA_COL])
                 # delete by matching all fields of document
                 where_conditions = []
                 for col in self._table.columns:

--- a/src/langchain_google_cloud_sql_mssql/mssql_loader.py
+++ b/src/langchain_google_cloud_sql_mssql/mssql_loader.py
@@ -13,42 +13,48 @@
 # limitations under the License.
 import json
 from collections.abc import Iterable
-from typing import Any, List, Optional, Sequence
+from typing import Any, Dict, Iterator, List, Optional, Sequence, cast
 
+import pytds
 import sqlalchemy
 from langchain_community.document_loaders.base import BaseLoader
 from langchain_core.documents import Document
 
 from langchain_google_cloud_sql_mssql.mssql_engine import MSSQLEngine
 
+DEFAULT_CONTENT_COL = "page_content"
 DEFAULT_METADATA_COL = "langchain_metadata"
 
 
-def _parse_doc_from_table(
-    content_columns: Iterable[str],
-    metadata_columns: Iterable[str],
-    column_names: Iterable[str],
-    rows: Sequence[Any],
-) -> List[Document]:
-    docs = []
-    for row in rows:
-        page_content = " ".join(
-            str(getattr(row, column))
-            for column in content_columns
-            if column in column_names
-        )
-        metadata = {
-            column: getattr(row, column)
-            for column in metadata_columns
-            if column in column_names
-        }
-        if DEFAULT_METADATA_COL in metadata:
-            extra_metadata = json.loads(metadata[DEFAULT_METADATA_COL])
-            del metadata[DEFAULT_METADATA_COL]
-            metadata |= extra_metadata
-        doc = Document(page_content=page_content, metadata=metadata)
-        docs.append(doc)
-    return docs
+def _parse_doc_from_row(
+    content_columns: Iterable[str], metadata_columns: Iterable[str], row: Dict
+) -> Document:
+    page_content = " ".join(
+        str(row[column]) for column in content_columns if column in row
+    )
+    metadata: Dict[str, Any] = {}
+    # unnest metadata from langchain_metadata column
+    if DEFAULT_METADATA_COL in metadata_columns and row.get(DEFAULT_METADATA_COL):
+        for k, v in row[DEFAULT_METADATA_COL].items():
+            metadata[k] = v
+    # load metadata from other columns
+    for column in metadata_columns:
+        if column in row and column != DEFAULT_METADATA_COL:
+            metadata[column] = row[column]
+    return Document(page_content=page_content, metadata=metadata)
+
+
+def _parse_row_from_doc(column_names: Iterable[str], doc: Document) -> Dict:
+    doc_metadata = doc.metadata.copy()
+    row: Dict[str, Any] = {DEFAULT_CONTENT_COL: doc.page_content}
+    for entry in doc.metadata:
+        if entry in column_names:
+            row[entry] = doc_metadata[entry]
+            del doc_metadata[entry]
+    # store extra metadata in langchain_metadata column in json format
+    if DEFAULT_METADATA_COL in column_names and len(doc_metadata) > 0:
+        row[DEFAULT_METADATA_COL] = doc_metadata
+    return row
 
 
 class MSSQLLoader(BaseLoader):
@@ -57,29 +63,13 @@ class MSSQLLoader(BaseLoader):
     def __init__(
         self,
         engine: MSSQLEngine,
-        query: str,
+        table_name: str = "",
+        query: str = "",
         content_columns: Optional[List[str]] = None,
         metadata_columns: Optional[List[str]] = None,
     ):
         """
-        Args:
-          engine (MSSQLEngine): MSSQLEngine object to connect to the MSSQL database.
-          query (str): The query to execute in MSSQL format.
-          content_columns (List[str]): The columns to write into the `page_content`
-             of the document. Optional.
-          metadata_columns (List[str]): The columns to write into the `metadata` of the document.
-             Optional.
-        """
-        self.engine = engine
-        self.query = query
-        self.content_columns = content_columns
-        self.metadata_columns = metadata_columns
-
-    def load(self) -> List[Document]:
-        """
-        Load langchain documents from a Cloud SQL MSSQL database.
-
-        Document page content defaults to the first columns present in the query or table and
+        Document page content defaults to the first column present in the query or table and
         metadata defaults to all other columns. Use with content_columns to overwrite the column
         used for page content. Use metadata_columns to select specific metadata columns rather
         than using all remaining columns.
@@ -87,21 +77,137 @@ class MSSQLLoader(BaseLoader):
         If multiple content columns are specified, page_content’s string format will default to
         space-separated string concatenation.
 
+        Args:
+          engine (MSSQLEngine): MSSQLEngine object to connect to the MSSQL database.
+          table_name (str): The MSSQL database table name. (OneOf: table_name, query).
+          query (str): The query to execute in MSSQL format.  (OneOf: table_name, query).
+          content_columns (List[str]): The columns to write into the `page_content`
+             of the document. Optional.
+          metadata_columns (List[str]): The columns to write into the `metadata` of the document.
+             Optional.
+        """
+        self.engine = engine
+        self.table_name = table_name
+        self.query = query
+        self.content_columns = content_columns
+        self.metadata_columns = metadata_columns
+        if not self.table_name and not self.query:
+            raise ValueError("One of 'table_name' or 'query' must be specified.")
+        if self.table_name and self.query:
+            raise ValueError(
+                "Cannot specify both 'table_name' and 'query'. Specify 'table_name' to load "
+                "entire table or 'query' to load a specific query."
+            )
+
+    def load(self) -> List[Document]:
+        """
+        Load langchain documents from a Cloud SQL MSSQL database.
+
         Returns:
             (List[langchain_core.documents.Document]): a list of Documents with metadata from
                 specific columns.
         """
+        return list(self.lazy_load())
+
+    def lazy_load(self) -> Iterator[Document]:
+        """
+        Lazy Load langchain documents from a Cloud SQL MSSQL database. Use lazy load to avoid
+        caching all documents in memory at once.
+
+        Returns:
+            (Iterator[langchain_core.documents.Document]): a list of Documents with metadata from
+                specific columns.
+        """
+        if self.query:
+            stmt = sqlalchemy.text(self.query)
+        else:
+            stmt = sqlalchemy.text(f'select * from "{self.table_name}";')
         with self.engine.connect() as connection:
-            result_proxy = connection.execute(sqlalchemy.text(self.query))
+            result_proxy = connection.execute(stmt)
             column_names = list(result_proxy.keys())
-            results = result_proxy.fetchall()
             content_columns = self.content_columns or [column_names[0]]
             metadata_columns = self.metadata_columns or [
                 col for col in column_names if col not in content_columns
             ]
-            return _parse_doc_from_table(
-                content_columns,
-                metadata_columns,
-                column_names,
-                results,
+            while True:
+                row = result_proxy.fetchone()
+                if not row:
+                    break
+                # Handle default metadata field
+                row_data = {}
+                for column in column_names:
+                    value = getattr(row, column)
+                    if column == DEFAULT_METADATA_COL:
+                        row_data[column] = json.loads(value)
+                    else:
+                        row_data[column] = value
+                yield _parse_doc_from_row(content_columns, metadata_columns, row_data)
+
+
+class MSSQLDocumentSaver:
+    """A class for saving langchain documents into a Cloud SQL MSSQL database table."""
+
+    def __init__(
+        self,
+        engine: MSSQLEngine,
+        table_name: str,
+    ):
+        """
+        MSSQLDocumentSaver allows for saving of langchain documents in a database. If the table
+        doesn't exists, a table with default schema will be created. The default schema:
+            - page_content (type: text)
+            - langchain_metadata (type: JSON)
+
+        Args:
+          engine: MSSQLEngine object to connect to the MSSQL database.
+          table_name: The name of table for saving documents.
+        """
+        self.engine = engine
+        self.table_name = table_name
+        self._table = self.engine._load_document_table(table_name)
+        if DEFAULT_CONTENT_COL not in self._table.columns.keys():
+            raise ValueError(
+                f"Missing '{DEFAULT_CONTENT_COL}' field in table {table_name}."
             )
+
+    def add_documents(self, docs: List[Document]) -> None:
+        """
+        Save documents in the DocumentSaver table. Document’s metadata is added to columns if found or
+        stored in langchain_metadata JSON column.
+
+        Args:
+            docs (List[langchain_core.documents.Document]): a list of documents to be saved.
+        """
+        with self.engine.connect() as conn:
+            for doc in docs:
+                row = _parse_row_from_doc(self._table.columns.keys(), doc)
+                for k, v in row.items():
+                    if type(v) == dict:
+                        row[k] = json.dumps(v)
+                conn.execute(sqlalchemy.insert(self._table).values(row))
+            conn.commit()
+
+    def delete(self, docs: List[Document]) -> None:
+        """
+        Delete all instances of a document from the DocumentSaver table by matching the entire Document
+        object.
+
+        Args:
+            docs (List[langchain_core.documents.Document]): a list of documents to be deleted.
+        """
+        with self.engine.connect() as conn:
+            for doc in docs:
+                row = _parse_row_from_doc(self._table.columns.keys(), doc)
+                for k, v in row.items():
+                    if type(v) == dict:
+                        row[k] = json.dumps(v)
+                # delete by matching all fields of document
+                where_conditions = []
+                for col in self._table.columns:
+                    where_conditions.append(col == row[col.name])
+                conn.execute(
+                    sqlalchemy.delete(self._table).where(
+                        sqlalchemy.and_(*where_conditions)
+                    )
+                )
+            conn.commit()

--- a/src/langchain_google_cloud_sql_mssql/mssql_loader.py
+++ b/src/langchain_google_cloud_sql_mssql/mssql_loader.py
@@ -15,7 +15,6 @@ import json
 from collections.abc import Iterable
 from typing import Any, Dict, Iterator, List, Optional, Sequence, cast
 
-import pytds
 import sqlalchemy
 from langchain_community.document_loaders.base import BaseLoader
 from langchain_core.documents import Document

--- a/tests/integration/test_mssql_loader.py
+++ b/tests/integration/test_mssql_loader.py
@@ -17,9 +17,14 @@ from typing import Generator
 
 import pytest
 import sqlalchemy
+from langchain.text_splitter import CharacterTextSplitter
 from langchain_core.documents import Document
 
-from langchain_google_cloud_sql_mssql import MSSQLEngine, MSSQLLoader
+from langchain_google_cloud_sql_mssql import (
+    MSSQLDocumentSaver,
+    MSSQLEngine,
+    MSSQLLoader,
+)
 
 project_id = os.environ["PROJECT_ID"]
 region = os.environ["REGION"]
@@ -58,7 +63,7 @@ def default_setup(engine):
                     CREATE TABLE [dbo].[{table_name}](
                         fruit_id INT IDENTITY(1,1) PRIMARY KEY,
                         fruit_name VARCHAR(100) NOT NULL,
-                        variety VARCHAR(50),  
+                        variety VARCHAR(50),
                         quantity_in_stock INT NOT NULL,
                         price_per_unit DECIMAL(6,2) NOT NULL,
                         organic BIT NOT NULL
@@ -275,3 +280,265 @@ def test_load_from_query_with_langchain_metadata(engine):
             },
         )
     ]
+
+
+def test_save_doc_with_default_metadata(engine):
+    engine.init_document_table(table_name)
+    test_docs = [
+        Document(
+            page_content="Apple Granny Smith 150 0.99 1",
+            metadata={"fruit_id": 1},
+        ),
+        Document(
+            page_content="Banana Cavendish 200 0.59 0",
+            metadata={"fruit_id": 2},
+        ),
+        Document(
+            page_content="Orange Navel 80 1.29 1",
+            metadata={"fruit_id": 3},
+        ),
+    ]
+    saver = MSSQLDocumentSaver(engine=engine, table_name=table_name)
+    loader = MSSQLLoader(engine=engine, table_name=table_name)
+
+    saver.add_documents(test_docs)
+    docs = loader.load()
+
+    assert docs == test_docs
+    assert engine._load_document_table(table_name).columns.keys() == [
+        "page_content",
+        "langchain_metadata",
+    ]
+
+
+@pytest.mark.parametrize("store_metadata", [True, False])
+def test_save_doc_with_customized_metadata(engine, store_metadata):
+    engine.init_document_table(
+        table_name,
+        metadata_columns=[
+            sqlalchemy.Column(
+                "fruit_name",
+                sqlalchemy.UnicodeText,
+                primary_key=False,
+                nullable=True,
+            ),
+            sqlalchemy.Column(
+                "organic",
+                sqlalchemy.Boolean,
+                primary_key=False,
+                nullable=True,
+            ),
+        ],
+        store_metadata=store_metadata,
+    )
+    test_docs = [
+        Document(
+            page_content="Granny Smith 150 0.99",
+            metadata={"fruit_id": 1, "fruit_name": "Apple", "organic": 1},
+        ),
+    ]
+    saver = MSSQLDocumentSaver(engine=engine, table_name=table_name)
+    loader = MSSQLLoader(
+        engine=engine,
+        table_name=table_name,
+        metadata_columns=[
+            "fruit_id",
+            "fruit_name",
+            "organic",
+        ],
+    )
+
+    saver.add_documents(test_docs)
+    docs = loader.load()
+
+    if store_metadata:
+        docs == test_docs
+        assert engine._load_document_table(table_name).columns.keys() == [
+            "page_content",
+            "fruit_name",
+            "organic",
+            "langchain_metadata",
+        ]
+    else:
+        assert docs == [
+            Document(
+                page_content="Granny Smith 150 0.99",
+                metadata={"fruit_name": "Apple", "organic": 1},
+            ),
+        ]
+        assert engine._load_document_table(table_name).columns.keys() == [
+            "page_content",
+            "fruit_name",
+            "organic",
+        ]
+
+
+def test_save_doc_without_metadata(engine):
+    engine.init_document_table(
+        table_name,
+        store_metadata=False,
+    )
+    test_docs = [
+        Document(
+            page_content="Granny Smith 150 0.99",
+            metadata={"fruit_id": 1, "fruit_name": "Apple", "organic": 1},
+        ),
+    ]
+    saver = MSSQLDocumentSaver(engine=engine, table_name=table_name)
+    loader = MSSQLLoader(
+        engine=engine,
+        table_name=table_name,
+    )
+
+    saver.add_documents(test_docs)
+    docs = loader.load()
+
+    assert docs == [
+        Document(
+            page_content="Granny Smith 150 0.99",
+            metadata={},
+        ),
+    ]
+    assert engine._load_document_table(table_name).columns.keys() == [
+        "page_content",
+    ]
+
+
+def test_delete_doc_with_default_metadata(engine):
+    engine.init_document_table(table_name)
+    test_docs = [
+        Document(
+            page_content="Apple Granny Smith 150 0.99 1",
+            metadata={"fruit_id": 1},
+        ),
+        Document(
+            page_content="Banana Cavendish 200 0.59 0 1",
+            metadata={"fruit_id": 2},
+        ),
+    ]
+    saver = MSSQLDocumentSaver(engine=engine, table_name=table_name)
+    loader = MSSQLLoader(engine=engine, table_name=table_name)
+
+    saver.add_documents(test_docs)
+    docs = loader.load()
+    assert docs == test_docs
+
+    saver.delete(docs[:1])
+    assert len(loader.load()) == 1
+
+    saver.delete(docs)
+    assert len(loader.load()) == 0
+
+
+@pytest.mark.parametrize("store_metadata", [True, False])
+def test_delete_doc_with_customized_metadata(engine, store_metadata):
+    engine.init_document_table(
+        table_name,
+        metadata_columns=[
+            sqlalchemy.Column(
+                "fruit_name",
+                sqlalchemy.UnicodeText,
+                primary_key=False,
+                nullable=True,
+            ),
+            sqlalchemy.Column(
+                "organic",
+                sqlalchemy.Boolean,
+                primary_key=False,
+                nullable=True,
+            ),
+        ],
+        store_metadata=store_metadata,
+    )
+    test_docs = [
+        Document(
+            page_content="Granny Smith 150 0.99",
+            metadata={"fruit-id": 1, "fruit_name": "Apple", "organic": 1},
+        ),
+        Document(
+            page_content="Cavendish 200 0.59 0",
+            metadata={"fruit_id": 2, "fruit_name": "Banana", "organic": 1},
+        ),
+    ]
+    saver = MSSQLDocumentSaver(engine=engine, table_name=table_name)
+    loader = MSSQLLoader(engine=engine, table_name=table_name)
+
+    saver.add_documents(test_docs)
+    docs = loader.load()
+    assert len(docs) == 2
+
+    saver.delete(docs[:1])
+    assert len(loader.load()) == 1
+
+    saver.delete(docs)
+    assert len(loader.load()) == 0
+
+
+def test_delete_doc_with_query(engine):
+    engine.init_document_table(
+        table_name,
+        metadata_columns=[
+            sqlalchemy.Column(
+                "fruit_name",
+                sqlalchemy.UnicodeText,
+                primary_key=False,
+                nullable=True,
+            ),
+            sqlalchemy.Column(
+                "organic",
+                sqlalchemy.Boolean,
+                primary_key=False,
+                nullable=True,
+            ),
+        ],
+        store_metadata=True,
+    )
+    test_docs = [
+        Document(
+            page_content="Granny Smith 150 0.99",
+            metadata={"fruit-id": 1, "fruit_name": "Apple", "organic": 1},
+        ),
+        Document(
+            page_content="Cavendish 200 0.59 0",
+            metadata={"fruit_id": 2, "fruit_name": "Banana", "organic": 0},
+        ),
+        Document(
+            page_content="Navel 80 1.29 1",
+            metadata={"fruit_id": 3, "fruit_name": "Orange", "organic": 1},
+        ),
+    ]
+    saver = MSSQLDocumentSaver(engine=engine, table_name=table_name)
+    loader = MSSQLLoader(engine=engine, table_name=table_name)
+    query = f"select * from \"{table_name}\" where fruit_name='Apple';"
+    query_loader = MSSQLLoader(engine=engine, query=query)
+
+    saver.add_documents(test_docs)
+    docs = query_loader.load()
+    assert len(docs) == 1
+
+    saver.delete(docs)
+    assert len(loader.load()) == 2
+
+
+def test_load_and_spilt(engine):
+    engine.init_document_table(table_name)
+    text_splitter = CharacterTextSplitter(
+        separator=" ",
+        chunk_size=10,
+        chunk_overlap=2,
+        length_function=len,
+        is_separator_regex=False,
+    )
+    test_docs = [
+        Document(
+            page_content="Apple Granny Smith 150 0.99 1",
+            metadata={"fruit_id": 1},
+        ),
+    ]
+    saver = MSSQLDocumentSaver(engine=engine, table_name=table_name)
+    loader = MSSQLLoader(engine=engine, table_name=table_name)
+
+    saver.add_documents(test_docs)
+    docs = loader.load_and_split(text_splitter=text_splitter)
+
+    assert len(docs) == 4

--- a/tests/unit/test_doc2row.py
+++ b/tests/unit/test_doc2row.py
@@ -1,0 +1,141 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from langchain_core.documents import Document
+
+from langchain_google_cloud_sql_mssql.mssql_loader import (
+    DEFAULT_CONTENT_COL,
+    DEFAULT_METADATA_COL,
+    _parse_doc_from_row,
+    _parse_row_from_doc,
+)
+
+test_doc = Document(
+    page_content="Granny Smith 150 0.99",
+    metadata={"fruit-id": 1, "fruit_name": "Apple", "organic": 1},
+)
+cols_default = [DEFAULT_CONTENT_COL, DEFAULT_METADATA_COL]
+row_default = {
+    "page_content": "Granny Smith 150 0.99",
+    "langchain_metadata": {"fruit-id": 1, "fruit_name": "Apple", "organic": 1},
+}
+row_customized_flat = {
+    "fruit-id": 1,
+    "fruit_name": "Apple",
+    "variety": "Granny Smith",
+    "quantity_in_stock": 150,
+    "price_per_unit": 0.99,
+    "organic": 1,
+}
+row_customized_nested = {
+    "variety": "Granny Smith",
+    "quantity_in_stock": 150,
+    "price_per_unit": 0.99,
+    "langchain_metadata": {"fruit-id": 1, "fruit_name": "Apple", "organic": 1},
+}
+
+
+def test_row2doc_default():
+    doc = _parse_doc_from_row(
+        [DEFAULT_CONTENT_COL], [DEFAULT_METADATA_COL], row_default
+    )
+    assert doc == test_doc
+
+
+def test_row2doc_customized():
+    doc = _parse_doc_from_row(
+        ["variety", "quantity_in_stock", "price_per_unit"],
+        ["fruit-id", "fruit_name", "organic"],
+        row_customized_flat,
+    )
+    assert doc == test_doc
+
+
+def test_row2doc_unnest_default_metadata():
+    doc = _parse_doc_from_row(
+        ["variety", "quantity_in_stock", "price_per_unit"],
+        ["langchain_metadata"],
+        row_customized_nested,
+    )
+    assert doc == test_doc
+
+
+def test_row2doc_ovrride_default_metadata():
+    row_override = row_customized_nested.copy()
+    row_override["fruit_name"] = "Banana"
+    assert _parse_doc_from_row(
+        ["quantity_in_stock", "price_per_unit"],
+        ["fruit_name", "variety", "langchain_metadata"],
+        row_override,
+    ) == Document(
+        page_content="150 0.99",
+        metadata={
+            "fruit-id": 1,
+            "variety": "Granny Smith",
+            "fruit_name": "Banana",
+            "organic": 1,
+        },
+    )
+
+
+def test_row2doc_metadata_col_nonexist():
+    assert _parse_doc_from_row(
+        ["variety", "quantity_in_stock", "price_per_unit"],
+        ["fruit-id"],
+        row_customized_nested,
+    ) == Document(page_content="Granny Smith 150 0.99")
+
+
+def test_doc2row_default():
+    assert _parse_row_from_doc(cols_default, test_doc) == row_default
+
+
+def test_doc2row_customized():
+    assert _parse_row_from_doc([DEFAULT_CONTENT_COL, "fruit-id"], test_doc) == {
+        "fruit-id": 1,
+        "page_content": "Granny Smith 150 0.99",
+    }
+
+
+def test_doc2row_no_metadata():
+    assert _parse_row_from_doc([DEFAULT_CONTENT_COL], test_doc) == {
+        "page_content": "Granny Smith 150 0.99",
+    }
+
+
+def test_doc2row_store_extra_metadata():
+    assert _parse_row_from_doc(
+        [DEFAULT_CONTENT_COL, "fruit-id", DEFAULT_METADATA_COL], test_doc
+    ) == {
+        "fruit-id": 1,
+        "page_content": "Granny Smith 150 0.99",
+        "langchain_metadata": {
+            "fruit_name": "Apple",
+            "organic": 1,
+        },
+    }
+
+
+def test_doc2row2doc_customized_metadata():
+    customized_metadatas = [
+        [],
+        ["fruit-id"],
+        ["fruit-id", "fruit_name", "organic"],
+        ["fruit-id", "fruit_name", "organic", "other"],
+    ]
+    for metadata in customized_metadatas:
+        assert test_doc == _parse_doc_from_row(
+            [DEFAULT_CONTENT_COL],
+            metadata + [DEFAULT_METADATA_COL],
+            _parse_row_from_doc(metadata + [DEFAULT_METADATA_COL], test_doc),
+        )


### PR DESCRIPTION
Add document saver class and support save/load/delete user journeys.

In detail:
- Load documents via default table
- Load documents via custom table/metadata
- Load documents via custom page content columns
- Load documents via custom metadata columns
- Initialize MySQLDocumentSaver with existing table
- Initialize custom MySQLDocumentSaver table & add documents with metadata
- Delete documents

The difference between MSSQL doc loader/saver to MySQL doc loader/saver is:
Because MSSQL doesn't have built-in JSON field, we only do JSON loads/dumps for default metadata field. For MySQL, we do JSON loads/dumps for all fields with field_type JSON.