### PR TITLE
chore: update method name to `init_chat_history_table`

### DIFF
--- a/src/langchain_google_cloud_sql_mssql/mssql_chat_message_history.py
+++ b/src/langchain_google_cloud_sql_mssql/mssql_chat_message_history.py
@@ -47,7 +47,7 @@ class MSSQLChatMessageHistory(BaseChatMessageHistory):
     def _verify_schema(self) -> None:
         """Verify table exists with required schema for MSSQLChatMessageHistory class.
 
-        Use helper method MSSQLEngine.create_chat_history_table(...) to create
+        Use helper method MSSQLEngine.init_chat_history_table(...) to create
         table with valid schema.
         """
         insp = sqlalchemy.inspect(self.engine.engine)
@@ -74,7 +74,7 @@ class MSSQLChatMessageHistory(BaseChatMessageHistory):
             raise AttributeError(
                 f"Table '{self.table_name}' does not exist. Please create "
                 "it before initializing MSSQLChatMessageHistory. See "
-                "MSSQLEngine.create_chat_history_table() for a helper method."
+                "MSSQLEngine.init_chat_history_table() for a helper method."
             )
 
     @property

--- a/src/langchain_google_cloud_sql_mssql/mssql_engine.py
+++ b/src/langchain_google_cloud_sql_mssql/mssql_engine.py
@@ -119,7 +119,7 @@ class MSSQLEngine:
         """
         return self.engine.connect()
 
-    def create_chat_history_table(self, table_name: str) -> None:
+    def init_chat_history_table(self, table_name: str) -> None:
         """Create table with schema required for MSSQLChatMessageHistory class.
 
         Required schema is as follows:

--- a/tests/integration/test_mssql_chat_message_history.py
+++ b/tests/integration/test_mssql_chat_message_history.py
@@ -59,7 +59,7 @@ def setup() -> Generator:
 
 
 def test_chat_message_history(memory_engine: MSSQLEngine) -> None:
-    memory_engine.create_chat_history_table(table_name)
+    memory_engine.init_chat_history_table(table_name)
     history = MSSQLChatMessageHistory(
         engine=memory_engine, session_id="test", table_name=table_name
     )
@@ -87,7 +87,7 @@ def test_chat_message_history_table_does_not_exist(memory_engine: MSSQLEngine) -
         # assert custom error message for missing table
         assert (
             exc_info.value.args[0]
-            == f"Table 'missing_table' does not exist. Please create it before initializing MSSQLChatMessageHistory. See MSSQLEngine.create_chat_history_table() for a helper method."
+            == f"Table 'missing_table' does not exist. Please create it before initializing MSSQLChatMessageHistory. See MSSQLEngine.init_chat_history_table() for a helper method."
         )
 
 


### PR DESCRIPTION
Update naming to match MySQL and Postgres for initializing table. Change `create` to `init`
