### PR TITLE
fix: use lazy refresh for Cloud SQL Connector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "langchain-community>=0.0.18, <1.0.0",
     "SQLAlchemy>=2.0.7, <3.0.0",
     "sqlalchemy-pytds>=1.0.0, <2.0.0",
-    "cloud-sql-python-connector[pytds]>=1.7.0, <2.0.0"
+    "cloud-sql-python-connector[pytds]>=1.10.0, <2.0.0"
 ]
 classifiers = [
     "Intended Audience :: Developers",

--- a/src/langchain_google_cloud_sql_mssql/engine.py
+++ b/src/langchain_google_cloud_sql_mssql/engine.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from typing import List, Optional
 
 import sqlalchemy
-from google.cloud.sql.connector import Connector
+from google.cloud.sql.connector import Connector, RefreshStrategy
 
 from .version import __version__
 
@@ -96,7 +96,9 @@ class MSSQLEngine:
                 Python Connector.
         """
         if cls._connector is None:
-            cls._connector = Connector(user_agent=USER_AGENT)
+            cls._connector = Connector(
+                user_agent=USER_AGENT, refresh_strategy=RefreshStrategy.LAZY
+            )
 
         # anonymous function to be used for SQLAlchemy 'creator' argument
         def getconn():


### PR DESCRIPTION
The Cloud SQL Python Connector just released a new version `v1.10.0`
that supports setting the `refresh_strategy` argument of the connector.

Setting the refresh strategy to lazy refresh is recommended for
serverless environments. As the default refresh strategy is to
have background refreshes occur to get the instance metadata and a fresh
certificate to use for the SSL/TLS connection.

However, these background refreshes can be throttled when serverless
environments scale to zero (Cloud Functions, Cloud Run etc.).

This PR will fix the ambiguous errors that are a result of the CPU being
throttled for the Cloud SQL Connector.
