### PR TITLE
feat: remove support for Python 3.8

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -27,7 +27,6 @@ branchProtectionRules:
     requiredStatusCheckContexts:
       - "cla/google"
       - "lint"
-      - "mssql-integration-test-pr-py38 (langchain-cloud-sql-testing)"
       - "mssql-integration-test-pr-py39 (langchain-cloud-sql-testing)"
       - "mssql-integration-test-pr-py310 (langchain-cloud-sql-testing)"
       - "mssql-integration-test-pr-py311 (langchain-cloud-sql-testing)"

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -34,11 +34,11 @@ These tests are registered as required tests in `.github/sync-repo-settings.yaml
 
 #### Trigger Setup
 
-Cloud Build triggers (for Python versions 3.8 to 3.11) were created with the following specs:
+Cloud Build triggers (for Python versions 3.9 to 3.11) were created with the following specs:
 
 ```YAML
-name: mssql-integration-test-pr-py38
-description: Run integration tests on PR for Python 3.8
+name: mssql-integration-test-pr-py39
+description: Run integration tests on PR for Python 3.9
 filename: integration.cloudbuild.yaml
 github:
   name: langchain-google-cloud-sql-mssql-python
@@ -55,7 +55,7 @@ substitutions:
   _INSTANCE_ID: <ADD_VALUE>
   _DB_NAME: <ADD_VALUE>
   _REGION: us-central1
-  _VERSION: "3.8"
+  _VERSION: "3.9"
 ```
 
 Use `gcloud builds triggers import --source=trigger.yaml` to create triggers via the command line

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ With `virtualenv`_, it’s possible to install this library without needing syst
 Supported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Python >= 3.8
+Python >= 3.9
 
 Mac/Linux
 ^^^^^^^^^

--- a/integration.cloudbuild.yaml
+++ b/integration.cloudbuild.yaml
@@ -26,7 +26,14 @@ steps:
   - id: Run integration tests
     name: python:${_VERSION}
     entrypoint: python
-    args: ["-m", "pytest", "--cov=langchain_google_cloud_sql_mssql", "--cov-config=.coveragerc", "tests/"]
+    args:
+      [
+        "-m",
+        "pytest",
+        "--cov=langchain_google_cloud_sql_mssql",
+        "--cov-config=.coveragerc",
+        "tests/",
+      ]
     env:
       - "PROJECT_ID=$PROJECT_ID"
       - "INSTANCE_ID=$_INSTANCE_ID"
@@ -46,7 +53,7 @@ substitutions:
   _INSTANCE_ID: test-mssql-instance
   _REGION: us-central1
   _DB_NAME: test
-  _VERSION: "3.8"
+  _VERSION: "3.9"
 
 options:
   dynamicSubstitutions: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 description = "LangChain integrations for Google Cloud SQL for SQL Server"
 readme = "README.rst"
 license = {file = "LICENSE"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     {name = "Google LLC", email = "googleapis-packages@google.com"}
 ]
@@ -20,7 +20,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Langchain v0.3 removes support for py3.8. 

Python 3.8 will be [EOL at the end of next month](https://endoflife.date/python) (Oct 2024).

Removing support of it from future versions to allow for LangChain package bump.
